### PR TITLE
🐛 fix peer disappearance bug on more than three peers

### DIFF
--- a/client/src/entity/player.js
+++ b/client/src/entity/player.js
@@ -1,6 +1,13 @@
 import { updateAnimation, updateMouseAnimation, updateFollowClickAnimation, updateInitAnimation } from "./player/animation";
 
 export function playerCreate(scene, x, y, name, chat, id) {
+  let idStr = "";
+  if (id == null) {
+    idStr = "isnull";
+  } else {
+    idStr = id;
+  }
+  console.log("playerCreate", scene.sceneName, name, idStr.substring(0, 5));
   const phaser = scene.physics.add.sprite(x, y, `${id}-down-2`, 1);
   phaser.setSize(20, 20, false).setOffset(0, 20);
 

--- a/client/src/scenes/common.js
+++ b/client/src/scenes/common.js
@@ -54,7 +54,17 @@ export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
       console.log("listenPlayerList", sceneName);
     }
     for (const [id, player] of Object.entries(data)) {
-      if (player.floor !== sceneName) return;
+      if (player.floor !== sceneName) {
+        if (debug) {
+          console.log(
+            "listenPlayerList skip",
+            id.substring(0, 5),
+            player.floor,
+            sceneName
+          );
+        }
+        continue;
+      }
 
       const directions = ["left", "right", "up", "down"];
       for (const direction of directions) {

--- a/client/src/scenes/common.js
+++ b/client/src/scenes/common.js
@@ -15,8 +15,10 @@ export const FLOOR_NAMES = {
 
 export function listenRemovePlayerOnPlayers(socket, sceneName, players) {
   socket.on("removePlayer", (data) => {
-    console.log("removePlayer", sceneName, data);
     if (players[data.id]) {
+      console.log("removePlayers", sceneName, data.id, data);
+      // this makes a problem
+      // scene.player will have an invalid player field.
       players[data.id].phaser.destroy(true);
       players[data.id].nameLabel.destroy(true);
       players[data.id].chatBubble.destroy(true);
@@ -44,7 +46,13 @@ export function listenRemovePlayerOnPlayer(
 
 // FIXME: too many arguments.
 export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
-  socket.on("playerList", (data) => {
+  socket.on("playerList", (data) => listener(data));
+  socket.on("debugPlayerList", (data) => listener(data, true));
+
+  function listener(data, debug) {
+    if (debug) {
+      console.log("listenPlayerList", sceneName);
+    }
     for (const [id, player] of Object.entries(data)) {
       if (player.floor !== sceneName) return;
 
@@ -52,6 +60,14 @@ export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
       for (const direction of directions) {
         for (let i = 1; i < 5; i += 1) {
           if (!phaserScene.textures.exists(`${player.id}-${direction}-${i}`)) {
+            if (debug) {
+              console.log(
+                "listenPlayerList load",
+                id.substring(0, 5),
+                `${player.id}-${direction}-${i}`,
+                `${ENV.URL_STATIC}${player.imgUrl}${direction}-${i}.png`
+              );
+            }
             phaserScene.load.image(
               `${player.id}-${direction}-${i}`,
               `${ENV.URL_STATIC}${player.imgUrl}${direction}-${i}.png`
@@ -60,8 +76,14 @@ export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
         }
       }
       phaserScene.load.once("complete", () => {
+        if (debug) {
+          console.log("listenPlayerList complete", id.substring(0, 5));
+        }
         // fixme do not use implicit boolean casting
         if (!players[id] || !players[id].phaser.scene) {
+          if (debug) {
+            console.log("listenPlayerList playerCreate", id.substring(0, 5));
+          }
           players[id] = playerCreate(
             phaserScene,
             player.x,
@@ -72,6 +94,12 @@ export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
           );
         } else {
           if (socket.id !== id) {
+            if (debug) {
+              console.log(
+                "listenPlayerList socket.id!==id",
+                id.substring(0, 5)
+              );
+            }
             if (players[id].phaser.depth === 0) {
               players[id].phaser.setDepth(1);
               players[id].nameLabel.setDepth(1);
@@ -86,12 +114,19 @@ export function listenPlayerList({ socket, sceneName, phaserScene, players }) {
             players[id].phaser.setTexture(
               `${player.id}-${player.direction}-${2}`
             );
+          } else {
+            if (debug) {
+              console.log(
+                "listenPlayerList socket.id===id",
+                id.substring(0, 5)
+              );
+            }
           }
         }
       });
       phaserScene.load.start();
     }
-  });
+  }
 }
 
 export function listenAddChat(socket, sceneName, players) {

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -150,7 +150,8 @@ def movePlayer(data):
 @socketio.on('getPlayers')
 def getPlayers():
     global players
-    emit('playerList', players)
+#    emit('playerList', players)
+    emit('debugPlayerList', players)
     emit('debugMessage', players)
 
 @socketio.on('disconnect')


### PR DESCRIPTION
We were using "return" in listPlayers event handling code when a peer does not match the scene. We must use "continue" instead. By using "return", other peers' information was not updated.